### PR TITLE
修复本地部署 SSL 证书问题

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -47,21 +47,21 @@ $ cp config.json.example config.json
 
 在执行 Let's Certbot 前，你有以下的配置需要更新:
 
-| 名称                         | 必须  | 描述                                       | 默认                  |
-| ---------------------------- | ----- | ------------------------------------------ | --------------------- |
-| base.email                   | true  | 邮箱地址，用于接收续期等通知               |                       |
-| api.aliyun.access_key_id     | true  | 阿里云帐号的 AccessKey ID                  |                       |
-| api.aliyun.access_key_secret | true  | 阿里云帐号的 AccessKey Secret              |                       |
-| log.enable                   | false | 是否启用日志跟踪                           | false                 |
-| log.logfile                  | false | 日志文件路径                               | ./log/application.log |
-| deploy.remotes               | false | 部署远端服务器列表                         |                       |
-| deploy.remote.enable         | false | 部署远端服务器是否启用部署脚本             | false                 |
-| deploy.remote.host           | false | 部署远端服务器地址，启用部署脚本后必须提供 |                       |
-| deploy.remote.port           | false | 部署远端服务器 SSH 守护进程绑定的端口      | 22                    |
-| deploy.remote.user           | false | 部署远端服务器登录的用户，用于执行部署脚本 | root                  |
-| deploy.remote.password       | false | 部署远端服务器登录的密码                   |                       |
-| deploy.remote.deploy_to      | false | 部署证书存储在远端服务器的路径             | /etc/letsencrypt/live |
-| deploy.remote.restart_nginx  | false | 是否在部署后重启远端服务器 nginx           | false                 |
+| 名称                         | 必须  | 描述                                   | 默认                  |
+| ---------------------------- | ----- | -------------------------------------- | --------------------- |
+| base.email                   | true  | 邮箱地址，用于接收续期等通知           |                       |
+| api.aliyun.access_key_id     | true  | 阿里云帐号的 AccessKey ID              |                       |
+| api.aliyun.access_key_secret | true  | 阿里云帐号的 AccessKey Secret          |                       |
+| log.enable                   | false | 是否启用日志跟踪                       | false                 |
+| log.logfile                  | false | 日志文件路径                           | ./log/application.log |
+| deploy.servers               | false | 部署服务器列表                         |                       |
+| deploy.server.enable         | false | 部署服务器是否启用部署脚本             | false                 |
+| deploy.server.host           | false | 部署服务器地址，启用部署脚本后必须提供 |                       |
+| deploy.server.port           | false | 部署服务器 SSH 守护进程绑定的端口      | 22                    |
+| deploy.server.user           | false | 部署服务器登录的用户，用于执行部署脚本 | root                  |
+| deploy.server.password       | false | 部署服务器登录的密码                   |                       |
+| deploy.server.deploy_to      | false | 部署证书存储在服务器的路径             | /etc/letsencrypt/live |
+| deploy.server.restart_nginx  | false | 是否在部署后重启服务器 nginx           | false                 |
 
 此外， `tlds.txt` 文件包含了一些顶级域名(TLD)和二级域名(SLD) 用于分开域名中的子域和主域。如果你域名中的顶级域或二级域不在 `tlds.txt` 中，你需要将它添加在此文件中。
 
@@ -117,11 +117,11 @@ $ sudo python ./bin/renewal.py --certs xny.example.com --force
 
 ### 部署证书
 
-如果你将 `deploy.remote.enable` 设置为 true, Certbot 将执行 deployment 脚本 (`deploy.py`) 在 deploy 钩子上。这个脚本接收到已经续期的证书并将它推送到配置好的服务器中。
+如果你将 `deploy.server.enable` 设置为 true, Certbot 将执行 deployment 脚本 (`deploy.py`) 在 deploy 钩子上。这个脚本接收到已经续期的证书并将它推送到配置好的服务器中。
 
-Let's Certbot 通过 SSH 部署证书，这意味着你执行 Certbot 的机器须通过 SSH 连接上部署机器。为了使连接成功，你需要**上传公钥**到部署机器或者**提供 `deploy.remote.password`** 给 `sshpass` 工具。
+Let's Certbot 通过 SSH 部署证书，这意味着你执行 Certbot 的机器须通过 SSH 连接上部署机器。为了使连接成功，你需要**上传公钥**到部署机器或者**提供 `deploy.server.password`** 给 `sshpass` 工具。
 
-此外，为了将证书部署到 `deploy.remote.deploy_to` 或重启 nginx, Let's Certbot 要求 `deploy.remote.user` 有执行对应操作的权限。
+此外，为了将证书部署到 `deploy.server.deploy_to` 或重启 nginx, Let's Certbot 要求 `deploy.server.user` 有执行对应操作的权限。
 
 你可以通过执行下面命令获取 deployment 脚本:
 
@@ -135,7 +135,7 @@ $ sudo python ./bin/deploy.py --check
 $ sudo python ./bin/deploy.py --push --cert $certificate_name --server $server_host
 ```
 
-**Note**: 如果 `deploy.remote` 以强制模式启动了 SELinux, 你需要确认 nginx 有权限访问 `deploy.remote.deploy_to` 的 SELinux 安全上下文。
+**Note**: 如果 `deploy.server` 以强制模式启动了 SELinux, 你需要确认 nginx 有权限访问 `deploy.server.deploy_to` 的 SELinux 安全上下文。
 
 ## 致谢
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -47,21 +47,21 @@ $ cp config.json.example config.json
 
 在执行 Let's Certbot 前，你有以下的配置需要更新:
 
-| 名称                         | 必须  | 描述                                   | 默认                  |
-| ---------------------------- | ----- | -------------------------------------- | --------------------- |
-| base.email                   | true  | 邮箱地址，用于接收续期等通知           |                       |
-| api.aliyun.access_key_id     | true  | 阿里云帐号的 AccessKey ID              |                       |
-| api.aliyun.access_key_secret | true  | 阿里云帐号的 AccessKey Secret          |                       |
-| log.enable                   | false | 是否启用日志跟踪                       | false                 |
-| log.logfile                  | false | 日志文件路径                           | ./log/application.log |
-| deploy.servers               | false | 部署服务器列表                         |                       |
-| deploy.server.enable         | false | 部署服务器是否启用部署脚本             | false                 |
-| deploy.server.host           | false | 部署服务器地址，启用部署脚本后必须提供 |                       |
-| deploy.server.port           | false | 部署服务器 SSH 守护进程绑定的端口      | 22                    |
-| deploy.server.user           | false | 部署服务器登录的用户，用于执行部署脚本 | root                  |
-| deploy.server.password       | false | 部署服务器登录的密码                   |                       |
-| deploy.server.deploy_to      | false | 部署证书存储在服务器的路径             | /etc/letsencrypt/live |
-| deploy.server.restart_nginx  | false | 是否在部署后重启服务器 nginx           | false                 |
+| 名称                         | 必须  | 描述                                                               | 默认                  |
+| ---------------------------- | ----- | ------------------------------------------------------------------ | --------------------- |
+| base.email                   | true  | 邮箱地址，用于接收续期等通知                                       |                       |
+| api.aliyun.access_key_id     | true  | 阿里云帐号的 AccessKey ID                                          |                       |
+| api.aliyun.access_key_secret | true  | 阿里云帐号的 AccessKey Secret                                      |                       |
+| log.enable                   | false | 是否启用日志跟踪                                                   | false                 |
+| log.logfile                  | false | 日志文件路径                                                       | ./log/application.log |
+| deploy.servers               | false | 部署服务器列表                                                     |                       |
+| deploy.server.enable         | false | 部署服务器是否启用部署脚本                                         | false                 |
+| deploy.server.host           | false | 部署服务器地址，本地服务器则使用 localhost，启用部署脚本后必须提供 |                       |
+| deploy.server.port           | false | 部署远程服务器 SSH 守护进程绑定的端口                              | 22                    |
+| deploy.server.user           | false | 部署远程服务器登录的用户，用于执行部署脚本                         | root                  |
+| deploy.server.password       | false | 部署远程服务器登录的密码                                           |                       |
+| deploy.server.deploy_to      | false | 部署证书存储在服务器的路径                                         | /etc/letsencrypt/live |
+| deploy.server.restart_nginx  | false | 是否在部署后重启服务器 nginx                                       | false                 |
 
 此外， `tlds.txt` 文件包含了一些顶级域名(TLD)和二级域名(SLD) 用于分开域名中的子域和主域。如果你域名中的顶级域或二级域不在 `tlds.txt` 中，你需要将它添加在此文件中。
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -47,23 +47,21 @@ $ cp config.json.example config.json
 
 在执行 Let's Certbot 前，你有以下的配置需要更新:
 
-| 名称                         | 必须  | 描述                                   | 默认                  |
-| ---------------------------- | ----- | -------------------------------------- | --------------------- |
-| base.email                   | true  | 邮箱地址，用于接收续期等通知           |                       |
-| api.aliyun.access_key_id     | true  | 阿里云帐号的 AccessKey ID              |                       |
-| api.aliyun.access_key_secret | true  | 阿里云帐号的 AccessKey Secret          |                       |
-| log.enable                   | false | 是否启用日志跟踪                       | false                 |
-| log.logfile                  | false | 日志文件路径                           | ./log/application.log |
-| deploy.enable                | false | 是否启用部署脚本                       | false                 |
-| deploy.keep_backups          | false | 备份证书数量                           | 2                     |
-| deploy.servers               | false | 部署服务器列表                         |                       |
-| deploy.server.host           | false | 部署服务器地址，启用部署脚本后必须提供 |                       |
-| deploy.server.port           | false | 部署服务器 SSH 守护进程绑定的端口      | 22                    |
-| deploy.server.user           | false | 部署服务器登录的用户，用于执行部署脚本 | root                  |
-| deploy.server.password       | false | 部署服务器登录的密码                   |                       |
-| deploy.server.deploy_to      | false | 部署证书存储的路径                     | /etc/letsencrypt/live |
-| deploy.server.nginx          | false | 部署服务器的 nginx 设置                |                       |
-| deploy.server.nginx.restart  | false | 是否在部署后重启 nginx                 | false                 |
+| 名称                         | 必须  | 描述                                       | 默认                  |
+| ---------------------------- | ----- | ------------------------------------------ | --------------------- |
+| base.email                   | true  | 邮箱地址，用于接收续期等通知               |                       |
+| api.aliyun.access_key_id     | true  | 阿里云帐号的 AccessKey ID                  |                       |
+| api.aliyun.access_key_secret | true  | 阿里云帐号的 AccessKey Secret              |                       |
+| log.enable                   | false | 是否启用日志跟踪                           | false                 |
+| log.logfile                  | false | 日志文件路径                               | ./log/application.log |
+| deploy.remotes               | false | 部署远端服务器列表                         |                       |
+| deploy.remote.enable         | false | 部署远端服务器是否启用部署脚本             | false                 |
+| deploy.remote.host           | false | 部署远端服务器地址，启用部署脚本后必须提供 |                       |
+| deploy.remote.port           | false | 部署远端服务器 SSH 守护进程绑定的端口      | 22                    |
+| deploy.remote.user           | false | 部署远端服务器登录的用户，用于执行部署脚本 | root                  |
+| deploy.remote.password       | false | 部署远端服务器登录的密码                   |                       |
+| deploy.remote.deploy_to      | false | 部署证书存储在远端服务器的路径             | /etc/letsencrypt/live |
+| deploy.remote.restart_nginx  | false | 是否在部署后重启远端服务器 nginx           | false                 |
 
 此外， `tlds.txt` 文件包含了一些顶级域名(TLD)和二级域名(SLD) 用于分开域名中的子域和主域。如果你域名中的顶级域或二级域不在 `tlds.txt` 中，你需要将它添加在此文件中。
 
@@ -119,11 +117,11 @@ $ sudo python ./bin/renewal.py --certs xny.example.com --force
 
 ### 部署证书
 
-如果你将 `deploy.enable` 设置为 true, Certbot 将执行 deployment 脚本 (`deploy.py`) 在 deploy 钩子上。这个脚本接收到已经续期的证书并将它推送到配置好的服务器中。
+如果你将 `deploy.remote.enable` 设置为 true, Certbot 将执行 deployment 脚本 (`deploy.py`) 在 deploy 钩子上。这个脚本接收到已经续期的证书并将它推送到配置好的服务器中。
 
-Let's Certbot 通过 SSH 部署证书，这意味着你执行 Certbot 的机器须通过 SSH 连接上部署机器。为了使连接成功，你需要**上传公钥**到部署机器或者**提供 `deploy.server.password`** 给 `sshpass` 工具。
+Let's Certbot 通过 SSH 部署证书，这意味着你执行 Certbot 的机器须通过 SSH 连接上部署机器。为了使连接成功，你需要**上传公钥**到部署机器或者**提供 `deploy.remote.password`** 给 `sshpass` 工具。
 
-此外，为了将证书部署到 `deploy.server.deploy_to` 或重启 nginx, Let's Certbot 要求 `deploy.server.user` 有执行对应操作的权限。
+此外，为了将证书部署到 `deploy.remote.deploy_to` 或重启 nginx, Let's Certbot 要求 `deploy.remote.user` 有执行对应操作的权限。
 
 你可以通过执行下面命令获取 deployment 脚本:
 
@@ -137,7 +135,7 @@ $ sudo python ./bin/deploy.py --check
 $ sudo python ./bin/deploy.py --push --cert $certificate_name --server $server_host
 ```
 
-**Note**: 如果 `deploy.server` 以强制模式启动了 SELinux, 你需要确认 nginx 有权限访问 `deploy.server.deploy_to` 的 SELinux 安全上下文。
+**Note**: 如果 `deploy.remote` 以强制模式启动了 SELinux, 你需要确认 nginx 有权限访问 `deploy.remote.deploy_to` 的 SELinux 安全上下文。
 
 ## 致谢
 

--- a/README.md
+++ b/README.md
@@ -49,23 +49,21 @@ $ cp config.json.example config.json
 
 Before running Let's Certbot, you have the following configuration to change:
 
-| Name                         | Required | Description                                               | Default               |
-| ---------------------------- | -------- | --------------------------------------------------------- | --------------------- |
-| base.email                   | true     | Email address for important renewal notifications         |                       |
-| api.aliyun.access_key_id     | true     | AccessKey ID of Aliyun account                            |                       |
-| api.aliyun.access_key_secret | true     | AccessKey Secret of Aliyun account                        |                       |
-| log.enable                   | false    | Whether to enable log tracker                             | false                 |
-| log.logfile                  | false    | The path of log file                                      | ./log/application.log |
-| deploy.enable                | false    | Whether to run deployment script                          | false                 |
-| deploy.keep_backups          | false    | The last n releases are kept for backups                  | 2                     |
-| deploy.servers               | false    | The deployment servers                                    |                       |
-| deploy.server.host           | false    | The host of deployment server, required on deploy         |                       |
-| deploy.server.port           | false    | The port of deployment server SSH daemon                  | 22                    |
-| deploy.server.user           | false    | The user of deployment server uses SSH login, run command | root                  |
-| deploy.server.password       | false    | The password of deployment user                           |                       |
-| deploy.server.deploy_to      | false    | The stored path of certificate                            | /etc/letsencrypt/live |
-| deploy.server.nginx          | false    | The nginx settings of deploy server                       |                       |
-| deploy.server.nginx.restart  | false    | Whether to restart nginx                                  | false                 |
+| Name                         | Required | Description                                                      | Default               |
+| ---------------------------- | -------- | ---------------------------------------------------------------- | --------------------- |
+| base.email                   | true     | Email address for important renewal notifications                |                       |
+| api.aliyun.access_key_id     | true     | AccessKey ID of Aliyun account                                   |                       |
+| api.aliyun.access_key_secret | true     | AccessKey Secret of Aliyun account                               |                       |
+| log.enable                   | false    | Whether to enable log tracker                                    | false                 |
+| log.logfile                  | false    | The path of log file                                             | ./log/application.log |
+| deploy.remotes               | false    | The deployment remote servers                                    |                       |
+| deploy.remote.enable         | false    | Whether to run deployment script for remote server               | false                 |
+| deploy.remote.host           | false    | The host of remote deployment server, required on deploy         |                       |
+| deploy.remote.port           | false    | The port of remote deployment server SSH daemon                  | 22                    |
+| deploy.remote.user           | false    | The user of remote deployment server uses SSH login, run command | root                  |
+| deploy.remote.password       | false    | The password of remote deployment user                           |                       |
+| deploy.remote.deploy_to      | false    | The stored path of certificate in remote server                  | /etc/letsencrypt/live |
+| deploy.remote.restart_nginx  | false    | Whether to restart nginx in remote server                        | false                 |
 
 In addition, `tlds.txt` contains some top level domains(TLD) and second level domains(SLD) for separating subdomain and main domain. If the TLD or SLD of your domain is not existed in `tlds.txt`, you need to append it in list.
 
@@ -121,11 +119,11 @@ $ sudo python ./bin/renewal.py --certs xny.example.com --force
 
 ### Deployment
 
-If you set `deploy.enable` to true, Certbot will run the deployment script (`deploy.py`) on deploy hook. The script receives renewed certificate and push it to configured servers.
+If you set `deploy.remote.enable` to true, Certbot will run the deployment script (`deploy.py`) on deploy hook. The script receives renewed certificate and push it to configured servers.
 
-Let's Certbot deploys certificate via SSH, it means that local server runs Certbot must be able to connect deployment server. In order to connect, you need to **add the public key** of local server to deployment server or **provide `deploy.server.password`** for `sshpass`.
+Let's Certbot deploys certificate via SSH, it means that local server runs Certbot must be able to connect deployment server. In order to connect, you need to **add the public key** of local server to deployment server or **provide `deploy.remote.password`** for `sshpass`.
 
-In order to add certificate to `deploy.server.deploy_to` or restart nginx, Let's Certbot requires `deploy.server.user` has permissions.
+In order to add certificate to `deploy.remote.deploy_to` or restart nginx, Let's Certbot requires `deploy.remote.user` has permissions.
 
 You can get deployment script by running the following command:
 
@@ -139,7 +137,7 @@ And push certificate to server:
 $ sudo python ./bin/deploy.py --push --cert $certificate_name --server $server_host
 ```
 
-**Note**: If `deploy.server` enables SELinux in enforcing mode, you need to confirm that nginx has access to the SElinux security context of `deploy.server.deploy_to`.
+**Note**: If `deploy.remote` enables SELinux in enforcing mode, you need to confirm that nginx has access to the SElinux security context of `deploy.remote.deploy_to`.
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -49,21 +49,21 @@ $ cp config.json.example config.json
 
 Before running Let's Certbot, you have the following configuration to change:
 
-| Name                         | Required | Description                                                      | Default               |
-| ---------------------------- | -------- | ---------------------------------------------------------------- | --------------------- |
-| base.email                   | true     | Email address for important renewal notifications                |                       |
-| api.aliyun.access_key_id     | true     | AccessKey ID of Aliyun account                                   |                       |
-| api.aliyun.access_key_secret | true     | AccessKey Secret of Aliyun account                               |                       |
-| log.enable                   | false    | Whether to enable log tracker                                    | false                 |
-| log.logfile                  | false    | The path of log file                                             | ./log/application.log |
-| deploy.remotes               | false    | The deployment remote servers                                    |                       |
-| deploy.remote.enable         | false    | Whether to run deployment script for remote server               | false                 |
-| deploy.remote.host           | false    | The host of remote deployment server, required on deploy         |                       |
-| deploy.remote.port           | false    | The port of remote deployment server SSH daemon                  | 22                    |
-| deploy.remote.user           | false    | The user of remote deployment server uses SSH login, run command | root                  |
-| deploy.remote.password       | false    | The password of remote deployment user                           |                       |
-| deploy.remote.deploy_to      | false    | The stored path of certificate in remote server                  | /etc/letsencrypt/live |
-| deploy.remote.restart_nginx  | false    | Whether to restart nginx in remote server                        | false                 |
+| Name                         | Required | Description                                               | Default               |
+| ---------------------------- | -------- | --------------------------------------------------------- | --------------------- |
+| base.email                   | true     | Email address for important renewal notifications         |                       |
+| api.aliyun.access_key_id     | true     | AccessKey ID of Aliyun account                            |                       |
+| api.aliyun.access_key_secret | true     | AccessKey Secret of Aliyun account                        |                       |
+| log.enable                   | false    | Whether to enable log tracker                             | false                 |
+| log.logfile                  | false    | The path of log file                                      | ./log/application.log |
+| deploy.servers               | false    | The deployment servers                                    |                       |
+| deploy.server.enable         | false    | Whether to run deployment script for server               | false                 |
+| deploy.server.host           | false    | The host of deployment server, required on deploy         |                       |
+| deploy.server.port           | false    | The port of deployment server SSH daemon                  | 22                    |
+| deploy.server.user           | false    | The user of deployment server uses SSH login, run command | root                  |
+| deploy.server.password       | false    | The password of deployment user                           |                       |
+| deploy.server.deploy_to      | false    | The stored path of certificate in server                  | /etc/letsencrypt/live |
+| deploy.server.restart_nginx  | false    | Whether to restart nginx in server                        | false                 |
 
 In addition, `tlds.txt` contains some top level domains(TLD) and second level domains(SLD) for separating subdomain and main domain. If the TLD or SLD of your domain is not existed in `tlds.txt`, you need to append it in list.
 
@@ -119,11 +119,11 @@ $ sudo python ./bin/renewal.py --certs xny.example.com --force
 
 ### Deployment
 
-If you set `deploy.remote.enable` to true, Certbot will run the deployment script (`deploy.py`) on deploy hook. The script receives renewed certificate and push it to configured servers.
+If you set `deploy.server.enable` to true, Certbot will run the deployment script (`deploy.py`) on deploy hook. The script receives renewed certificate and push it to configured servers.
 
-Let's Certbot deploys certificate via SSH, it means that local server runs Certbot must be able to connect deployment server. In order to connect, you need to **add the public key** of local server to deployment server or **provide `deploy.remote.password`** for `sshpass`.
+Let's Certbot deploys certificate via SSH, it means that local server runs Certbot must be able to connect deployment server. In order to connect, you need to **add the public key** of local server to deployment server or **provide `deploy.server.password`** for `sshpass`.
 
-In order to add certificate to `deploy.remote.deploy_to` or restart nginx, Let's Certbot requires `deploy.remote.user` has permissions.
+In order to add certificate to `deploy.server.deploy_to` or restart nginx, Let's Certbot requires `deploy.server.user` has permissions.
 
 You can get deployment script by running the following command:
 
@@ -137,7 +137,7 @@ And push certificate to server:
 $ sudo python ./bin/deploy.py --push --cert $certificate_name --server $server_host
 ```
 
-**Note**: If `deploy.remote` enables SELinux in enforcing mode, you need to confirm that nginx has access to the SElinux security context of `deploy.remote.deploy_to`.
+**Note**: If `deploy.server` enables SELinux in enforcing mode, you need to confirm that nginx has access to the SElinux security context of `deploy.server.deploy_to`.
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -49,21 +49,21 @@ $ cp config.json.example config.json
 
 Before running Let's Certbot, you have the following configuration to change:
 
-| Name                         | Required | Description                                               | Default               |
-| ---------------------------- | -------- | --------------------------------------------------------- | --------------------- |
-| base.email                   | true     | Email address for important renewal notifications         |                       |
-| api.aliyun.access_key_id     | true     | AccessKey ID of Aliyun account                            |                       |
-| api.aliyun.access_key_secret | true     | AccessKey Secret of Aliyun account                        |                       |
-| log.enable                   | false    | Whether to enable log tracker                             | false                 |
-| log.logfile                  | false    | The path of log file                                      | ./log/application.log |
-| deploy.servers               | false    | The deployment servers                                    |                       |
-| deploy.server.enable         | false    | Whether to run deployment script for server               | false                 |
-| deploy.server.host           | false    | The host of deployment server, required on deploy         |                       |
-| deploy.server.port           | false    | The port of deployment server SSH daemon                  | 22                    |
-| deploy.server.user           | false    | The user of deployment server uses SSH login, run command | root                  |
-| deploy.server.password       | false    | The password of deployment user                           |                       |
-| deploy.server.deploy_to      | false    | The stored path of certificate in server                  | /etc/letsencrypt/live |
-| deploy.server.restart_nginx  | false    | Whether to restart nginx in server                        | false                 |
+| Name                         | Required | Description                                                                          | Default               |
+| ---------------------------- | -------- | ------------------------------------------------------------------------------------ | --------------------- |
+| base.email                   | true     | Email address for important renewal notifications                                    |                       |
+| api.aliyun.access_key_id     | true     | AccessKey ID of Aliyun account                                                       |                       |
+| api.aliyun.access_key_secret | true     | AccessKey Secret of Aliyun account                                                   |                       |
+| log.enable                   | false    | Whether to enable log tracker                                                        | false                 |
+| log.logfile                  | false    | The path of log file                                                                 | ./log/application.log |
+| deploy.servers               | false    | The deployment servers                                                               |                       |
+| deploy.server.enable         | false    | Whether to run deployment script for server                                          | false                 |
+| deploy.server.host           | false    | The host of deployment server, set "localhost" for local server, required on deploy. |                       |
+| deploy.server.port           | false    | The port of remote server SSH daemon                                                 | 22                    |
+| deploy.server.user           | false    | The user of remote server uses SSH login, run command                                | root                  |
+| deploy.server.password       | false    | The password of remote user                                                          |                       |
+| deploy.server.deploy_to      | false    | The stored path of certificate in server                                             | /etc/letsencrypt/live |
+| deploy.server.restart_nginx  | false    | Whether to restart nginx in server                                                   | false                 |
 
 In addition, `tlds.txt` contains some top level domains(TLD) and second level domains(SLD) for separating subdomain and main domain. If the TLD or SLD of your domain is not existed in `tlds.txt`, you need to append it in list.
 

--- a/bin/deploy.py
+++ b/bin/deploy.py
@@ -9,128 +9,7 @@ root_path = os.path.sep.join([os.path.split(os.path.realpath(__file__))[0], '..'
 certs_root_path = '/etc/letsencrypt/live'
 
 sys.path.append(root_path)
-from lib import Config, Logger
-
-script_template = '''
-    # define variables
-    ssh_options="-o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-    timestamp=$(date +%%Y%%m%%d%%H%%M%%S)
-    tmp_dir="/tmp/letscertbot-$timestamp"
-    cert_name=$(basename '%(cert_path)s')
-
-    server="%(user)s@%(host)s"
-    deploy_path="%(deploy_to)s"
-    deploy_cert_path="$deploy_path/$cert_name"
-    backup_path="$deploy_path/backup"
-    backup_cert_path="$backup_path/$cert_name"
-
-    # define function
-    alert () { echo "Alert: $1"; }
-    success () { echo "\033[0;32mSuccess: $1\033[0m"; }
-    cmd_info () { echo "\033[1;33mCommand: $1\033[0m"; }
-    error () { echo "\033[0;31mError: $1\033[0m" >&2; exit 1; }
-
-    run_remote () {
-        cmd="$1"
-        use_ssh=${2:-1}
-
-        if [ $use_ssh -eq 1 ]; then
-            [ -n "%(password)s" ] || ssh_options="$ssh_options -o BatchMode=yes"
-            cmd="ssh $ssh_options -p %(port)s $server '$cmd'"
-        fi
-        [ -n "%(password)s" ] && cmd="sshpass -p %(password)s $cmd"
-
-        cmd_info "$cmd"
-        eval $cmd
-    }
-
-    # check sshpass if it is password mode
-    if [ -n "%(password)s" ]; then
-        alert "Checking if sshpass is installed:"
-        [ "$(command -v sshpass)" ] || error "sshpass is not installed. In order to connect deployment server, you need to install sshpass"
-        success "sshpass has been installed"
-    fi
-
-    alert "Trying connect to server by ssh:"
-    run_remote "exit 0"
-    [ $? -ne 0 ] && error "ssh connect to server $server failed"
-    success "Connected to $server"
-
-    alert "Creating tmp directory in server:"
-    run_remote "mkdir -p $tmp_dir"
-    [ $? -ne 0 ] && error "mkdir $tmp_dir in $server failed"
-    success "Created tmp directory in $server"
-
-    alert "Pushing cert files to server:"
-    run_remote "scp $ssh_options -P %(port)s -r '%(cert_path)s' $server:$tmp_dir" 0
-    [ $? -ne 0 ] && error "scp '%(cert_path)s' to $server:$tmp_dir failed"
-    success "Pushed cert files to $server:$tmp_dir"
-
-    alert "Cleaning up old backup cert in server:"
-    run_remote "[ -d $backup_cert_path ]"
-    if [ $? -eq 0 ]; then
-        run_remote "rm -rf \"$backup_cert_path\""
-        [ $? -ne 0 ] && error "Clean up old backup cert in $server failed"
-        success "Cleaned up old backup cert in $server"
-    else
-        alert "It is not need to clean up beacause current backup files are not existed"
-    fi
-
-    alert "Backuping used cert in server:"
-    run_remote "[ -d \"$deploy_cert_path\" ]"
-    if [ $? -eq 0 ]; then
-        run_remote "mkdir -p \"$backup_path\""
-        [ $? -ne 0 ] && error "Create \"$backup_path\" in $server failed"
-        run_remote "mv -Z \"$deploy_cert_path\" \"$backup_path\""
-        [ $? -ne 0 ] && error "Move \"$deploy_cert_path\" to \"$backup_path\" in $server failed"
-        success "Backuped cert into $backup_cert_path in $server"
-    else
-        alert "\"$deploy_cert_path\" is not found, not need to backup"
-    fi
-
-    alert "Trying create deploy to directory in server:"
-    run_remote "mkdir -p $deploy_path"
-    [ $? -ne 0 ] && error "Create $deploy_path directory in $server failed"
-    success "Create $deploy_path directory in $server"
-
-    alert "Moving new cert to deploy directory in server:"
-    run_remote "mv -Z \"$tmp_dir/$cert_name\" \"$deploy_cert_path\""
-    [ $? -ne 0 ] && error "Move \"$tmp_dir/$cert_name\" to \"$deploy_cert_path\" in $server failed"
-    success "Moved new cert to $deploy_cert_path in $server"
-
-    alert "Removing tmp directory in server:"
-    run_remote "rm -r \"$tmp_dir\""
-    [ $? -ne 0 ] && error "Remove \"$tmp_dir\" in $server failed"
-    success "Moved new cert to $tmp_dir in $server"
-
-    if [ "%(restart_nginx)i" -gt 0 ]; then
-        alert "Trying restart nginx in server:"
-
-        alert "Checking if nginx is installed:"
-        run_remote "command -v nginx > /dev/null"
-        [ $? -ne 0 ] && error "Nginx is not found, add nginx to PATH environment if nginx is installed"
-
-        alert "Checking nginx configuration file:"
-        run_remote "nginx -t 2> /dev/null"
-        [ $? -ne 0 ] && error "Nginx configuration file test failed in $server"
-
-        run_remote "command -v systemctl > /dev/null"
-        if [ $? -eq 0 ]; then
-            run_remote "systemctl reload nginx"
-            [ $? -ne 0 ] && error "Restart nginx by 'systemctl reload nginx' in $server failed"
-        else
-            run_remote "command -v service > /dev/null"
-            if [ $? -eq 0 ]; then
-                run_remote "service reload nginx"
-                [ $? -ne 0 ] && error "Restart nginx by 'service reload nginx' in $server failed"
-            else
-                run_remote "nginx -s reload"
-                [ $? -ne 0 ] && error "nginx -s reload in $server failed"
-            fi
-        fi
-        success "Restarted nginx in $server"
-    fi
-'''
+from lib import Config, Logger, ScriptTemplates
 
 def run():
     try:
@@ -152,13 +31,13 @@ def run():
 
 def deploy():
     try:
-        remotes = Config['deploy'].get('remotes', None)
+        servers = Config['deploy'].get('servers', None)
 
-        if not (remotes and len(remotes) > 0):
-            print('deploy remotes is empty in config file')
+        if not (servers and len(servers) > 0):
+            print('deploy servers is empty in config file')
             return
 
-        for server in remotes:
+        for server in servers:
             if not server:
                 continue
             if server.get('enable', False):
@@ -166,58 +45,48 @@ def deploy():
                 script = build_script(server)
                 os.system(script)
             else:
-                print('server host: ' + server.get('host', 'Undefined') + 'has not enable deployment')
+                print('server host: ' + server.get('host', 'Undefined') + 'has been disable for deployment  in config.json')
     except Exception as e:
         Logger.error('deploy#deploy raise Exception:' + str(e))
 
 def check(cert_name, server_host):
     cert_path = os.path.sep.join([certs_root_path, cert_name or 'your_domain.com'])
-    server = next((x for x in Config['deploy']['remotes'] if x['host'] == server_host), {
+    server = next((x for x in Config['deploy']['servers'] if x['host'] == server_host), {
         'host': server_host,
         'user': 'root'
     })
-
     script = build_script(server, cert_path)
-
     print(script)
 
 def push(cert_name, server_host):
     try:
         cert_path = os.path.sep.join([certs_root_path, cert_name])
-        server = next((x for x in Config['deploy']['remotes'] if x['host'] == server_host), None)
+        server = next((x for x in Config['deploy']['servers'] if x['host'] == server_host), None)
 
         if server is None:
             raise Exception('Server host: ' + server_host + 'is not found in config.json')
 
+        if not server.get('enable', False):
+            print('server host: ' + server_host + 'has been disable for deployment in config.json')
+
         script = build_script(server, cert_path)
 
         print('deploy#push start to run script:')
-
         os.system(script)
-
         print('deploy#push end script')
     except Exception as e:
         print("deploy#push raise Exception: " + str(e))
 
 def build_script(server, cert_path = None):
-    user = server.get('usefalser', None) or 'root'
-    password = server.get('password', '')
-    port = server.get('port', None) or 22
-    deploy_to = server.get('deploy_to', None) or certs_root_path
-    restart_nginx = server.get('restart_nginx', False) or False
-
-    return script_template % {
-            'restart_nginx': restart_nginx,
-            'cert_path': _escape(cert_path or os.environ['RENEWED_LINEAGE']),
-            'host': _escape(server['host']),
-            'port': _escape(port),
-            'user': _escape(user),
-            'password': _escape(password),
-            "deploy_to": _escape(deploy_to),
-        }
-
-def _escape(string):
-    return str(string).replace("'", "\\'").replace('"', '\\"').replace(' ', '\\ ')
+    return ScriptTemplates.deploy_script({
+        'cert_path': cert_path or os.environ['RENEWED_LINEAGE'],
+        'deploy_to': server.get('deploy_to', None) or certs_root_path,
+        'host': server['host'],
+        'port': server.get('port', None) or 22,
+        'user': server.get('user', None) or 'root',
+        'password': server.get('password', ''),
+        'restart_nginx': server.get('restart_nginx', False)
+    })
 
 def main():
     parser = argparse.ArgumentParser(description='example: python %s --check' % os.path.basename(__file__))

--- a/bin/deploy.py
+++ b/bin/deploy.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import time
 import argparse
 
 root_path = os.path.sep.join([os.path.split(os.path.realpath(__file__))[0], '..'])
@@ -41,9 +42,9 @@ def deploy():
             if not server:
                 continue
             if server.get('enable', False):
-                print('start to deploy server host: ' + server.get('host', 'Undefined'))
                 script = build_script(server)
                 os.system(script)
+                time.sleep(1)
             else:
                 print('server host: ' + server.get('host', 'Undefined') + ' has been disable for deployment in config.json')
     except Exception as e:

--- a/bin/deploy.py
+++ b/bin/deploy.py
@@ -45,7 +45,7 @@ def deploy():
                 script = build_script(server)
                 os.system(script)
             else:
-                print('server host: ' + server.get('host', 'Undefined') + 'has been disable for deployment  in config.json')
+                print('server host: ' + server.get('host', 'Undefined') + ' has been disable for deployment in config.json')
     except Exception as e:
         Logger.error('deploy#deploy raise Exception:' + str(e))
 
@@ -64,10 +64,11 @@ def push(cert_name, server_host):
         server = next((x for x in Config['deploy']['servers'] if x['host'] == server_host), None)
 
         if server is None:
-            raise Exception('Server host: ' + server_host + 'is not found in config.json')
+            raise Exception('Server host: ' + server_host + ' is not found in config.json')
 
         if not server.get('enable', False):
-            print('server host: ' + server_host + 'has been disable for deployment in config.json')
+            print('server host: ' + server_host + ' has been disable for deployment in config.json')
+            return
 
         script = build_script(server, cert_path)
 

--- a/bin/obtain.py
+++ b/bin/obtain.py
@@ -8,7 +8,7 @@ import argparse
 root_path = os.path.sep.join([os.path.split(os.path.realpath(__file__))[0], '..'])
 
 sys.path.append(root_path)
-from lib import Config, Logger
+from lib import Config, Logger, Utils
 
 manual_path = os.path.sep.join([root_path, 'bin', 'manual.py'])
 deploy_path = os.path.sep.join([root_path, 'bin', 'deploy.py'])
@@ -36,7 +36,7 @@ def run(args):
 
     Logger.info('obtain domains: ' + domains)
 
-    deploy_hook = '--deploy-hook "python ' + deploy_path + '"' if 'enable' in Config['deploy'] and Config['deploy']['enable'] else ''
+    deploy_hook = '--deploy-hook "python ' + deploy_path + '"' if Utils.is_enable_deployment() else ''
     cert_name = '--cert-name ' + args.cert if args.cert else ''
     force_renewal = '--force-renewal' if args.force else ''
 

--- a/bin/renewal.py
+++ b/bin/renewal.py
@@ -8,7 +8,7 @@ import argparse
 root_path = os.path.sep.join([os.path.split(os.path.realpath(__file__))[0], '..'])
 
 sys.path.append(root_path)
-from lib import Config, Logger
+from lib import Config, Logger, Utils
 
 manual_path = os.path.sep.join([root_path, 'bin', 'manual.py'])
 deploy_path = os.path.sep.join([root_path, 'bin', 'deploy.py'])
@@ -34,7 +34,7 @@ def run(args):
 
     force_renewal = '--force-renewal' if args.force else ''
 
-    deploy_hook = '--deploy-hook "python ' + deploy_path + '"' if 'enable' in Config['deploy'] and Config['deploy']['enable'] else ''
+    deploy_hook = '--deploy-hook "python ' + deploy_path + '"' if Utils.is_enable_deployment() else ''
 
     certbot_cmd = certbot_cmd_template % {
         'manual_path': manual_path,

--- a/config.json.example
+++ b/config.json.example
@@ -13,7 +13,7 @@
     "logfile": "./log/application.log"
   },
   "deploy": {
-    "remotes": [
+    "servers": [
       {
         "enable": false,
         "host": "192.168.1.1",

--- a/config.json.example
+++ b/config.json.example
@@ -16,6 +16,12 @@
     "servers": [
       {
         "enable": false,
+        "host": "localhost",
+        "deploy_to": "",
+        "restart_nginx": false
+      },
+      {
+        "enable": false,
         "host": "192.168.1.1",
         "port": 22,
         "user": "root",

--- a/config.json.example
+++ b/config.json.example
@@ -13,18 +13,15 @@
     "logfile": "./log/application.log"
   },
   "deploy": {
-    "enable": false,
-    "keep_backups": 2,
-    "servers": [
+    "remotes": [
       {
+        "enable": false,
         "host": "192.168.1.1",
         "port": 22,
         "user": "root",
         "password": "",
         "deploy_to": "/etc/letsencrypt/live",
-        "nginx": {
-          "restart": false
-        }
+        "restart_nginx": false
       }
     ]
   }

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__all__ = ['Config', 'Logger', 'Utils']
+__all__ = ['Config', 'Logger', 'Utils', 'ScriptTemplates']
 
 from lib.config import Config
 from lib.logger import Logger
 import lib.utils as Utils
+import lib.script_templates as ScriptTemplates

--- a/lib/script_templates.py
+++ b/lib/script_templates.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import textwrap
+
+root_path = os.path.sep.join([os.path.split(os.path.realpath(__file__))[0], '..'])
+sys.path.append(root_path)
+
+from lib import Utils
+
+def deploy_script(options):
+    return DeployScriptTemplate(options).build()
+
+class BaseScriptTemplate(object):
+    def __init__(self, options):
+        self.options = options
+
+    def escape(self, string):
+        return str(string).replace("'", "\\'").replace('"', '\\"').replace(' ', '\\ ')
+
+    def escape_options(self, key):
+        return self.escape(self.options[key])
+
+class DeployScriptTemplate(BaseScriptTemplate):
+    def __init__(self, options):
+        super(DeployScriptTemplate, self).__init__(options)
+
+        self.is_localhost = Utils.is_localhost(options['host'])
+
+    def build(self):
+        return os.linesep.join([
+            self.build_common_script(),
+            (self.build_locale_script() if self.is_localhost else self.build_remote_script()),
+            self.build_migrate_script(),
+            self.build_nginx_script()
+        ])
+
+    def build_common_script(self):
+        script = textwrap.dedent('''
+            # define variables
+            timestamp=$(date +%%Y%%m%%d%%H%%M%%S)
+            tmp_dir="/tmp/letscertbot-$timestamp"
+
+            cert_path='%(cert_path)s'
+            cert_name=$(basename $cert_path)
+
+            deploy_path="%(deploy_to)s"
+            deploy_cert_path="$deploy_path/$cert_name"
+            backup_path="$deploy_path/backup"
+            backup_cert_path="$backup_path/$cert_name"
+
+            # define function
+            alert () { echo "Alert: $1"; }
+            success () { echo -e "\033[32mSuccess: $1\033[0m"; }
+            cmd_info () { echo -e "\033[33mCommand: $1\033[0m"; }
+            error () { echo -e "\033[31mError: $1\033[0m" >&2; exit 1; }
+        ''')
+
+        return script % {
+            'cert_path': self.escape_options('cert_path'),
+            'deploy_to': self.escape_options('deploy_to')
+        }
+
+    def build_locale_script(self):
+        return textwrap.dedent('''
+            server="%(host)s"
+
+            run () {
+                cmd_info "$1"
+                eval "$1"
+            }
+
+            copy_certs () {
+                run "cp -r $cert_path $tmp_dir"
+            }
+        ''') % {
+            'host': self.escape_options('host')
+        }
+
+    def build_remote_script(self):
+        return textwrap.dedent('''
+            ssh_options="-o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+            server="%(user)s@%(host)s"
+            port="%(port)s"
+            password="%(password)s"
+
+            run () {
+                cmd="$1"
+                use_ssh=${2:-1}
+
+                if [ $use_ssh -eq 1 ]; then
+                    [ -n $password ] || ssh_options="$ssh_options -o BatchMode=yes"
+                    cmd="ssh $ssh_options -p $port $server '$cmd'"
+                fi
+                [ -n $password ] && cmd="sshpass -p $password $cmd"
+
+                cmd_info "$cmd"
+                eval $cmd
+            }
+
+            copy_certs () {
+                run "scp $ssh_options -P $port -r $cert_path $server:$tmp_dir" 0
+            }
+
+            # check sshpass if it is password mode
+            if [ -n $password ]; then
+                alert "Checking if sshpass is installed:"
+                [ "$(command -v sshpass)" ] || error "sshpass is not installed. In order to connect deployment server, you need to install sshpass"
+                success "sshpass has been installed"
+            fi
+
+            alert "Trying connect to server by ssh:"
+            run "exit 0"
+            [ $? -ne 0 ] && error "ssh connect to server $server failed"
+            success "Connected to $server"
+        ''') % {
+            'user': self.escape_options('user'),
+            'host': self.escape_options('host'),
+            'port': self.escape_options('port'),
+            'password': self.escape_options('password')
+        }
+
+    def build_migrate_script(self):
+        return textwrap.dedent('''
+            alert "Creating tmp directory in server:"
+            run "mkdir -p $tmp_dir"
+            [ $? -ne 0 ] && error "mkdir $tmp_dir in $server failed"
+            success "Created tmp directory in $server"
+
+            alert "Pushing cert files to server:"
+            copy_certs
+            [ $? -ne 0 ] && error "Copy $cert_path to $server:$tmp_dir failed"
+            success "Pushed cert files to $server:$tmp_dir"
+
+            alert "Cleaning up old backup cert in server:"
+            run "[ -d $backup_cert_path ]"
+            if [ $? -eq 0 ]; then
+                run "rm -rf \"$backup_cert_path\""
+                [ $? -ne 0 ] && error "Clean up old backup cert in $server failed"
+                success "Cleaned up old backup cert in $server"
+            else
+                alert "It is not need to clean up beacause current backup files are not existed"
+            fi
+
+            alert "Backuping used cert in server:"
+            run "[ -d \"$deploy_cert_path\" ]"
+            if [ $? -eq 0 ]; then
+                run "mkdir -p \"$backup_path\""
+                [ $? -ne 0 ] && error "Create \"$backup_path\" in $server failed"
+                run "mv -Z \"$deploy_cert_path\" \"$backup_path\""
+                [ $? -ne 0 ] && error "Move \"$deploy_cert_path\" to \"$backup_path\" in $server failed"
+                success "Backuped cert into $backup_cert_path in $server"
+            else
+                alert "\"$deploy_cert_path\" is not found, not need to backup"
+            fi
+
+            alert "Trying create deploy to directory in server:"
+            run "mkdir -p $deploy_path"
+            [ $? -ne 0 ] && error "Create $deploy_path directory in $server failed"
+            success "Create $deploy_path directory in $server"
+
+            alert "Moving new cert to deploy directory in server:"
+            run "mv -Z \"$tmp_dir/$cert_name\" \"$deploy_cert_path\""
+            [ $? -ne 0 ] && error "Move \"$tmp_dir/$cert_name\" to \"$deploy_cert_path\" in $server failed"
+            success "Moved new cert to $deploy_cert_path in $server"
+
+            alert "Removing tmp directory in server:"
+            run "rm -r \"$tmp_dir\""
+            [ $? -ne 0 ] && error "Remove \"$tmp_dir\" in $server failed"
+            success "Moved new cert to $tmp_dir in $server"
+        ''')
+
+    def build_nginx_script(self):
+        if not self.options.get('restart_nginx', False):
+            return ''
+
+        return textwrap.dedent('''
+            alert "Trying restart nginx in server:"
+
+            alert "Checking if nginx is installed:"
+            run "command -v nginx > /dev/null"
+            [ $? -ne 0 ] && error "Nginx is not found, add nginx to PATH environment if nginx is installed"
+
+            alert "Checking nginx configuration file:"
+            run "nginx -t 2> /dev/null"
+            [ $? -ne 0 ] && error "Nginx configuration file test failed in $server"
+
+            run "command -v systemctl > /dev/null"
+            if [ $? -eq 0 ]; then
+                run "systemctl reload nginx"
+                [ $? -ne 0 ] && error "Restart nginx by 'systemctl reload nginx' in $server failed"
+            else
+                run "command -v service > /dev/null"
+                if [ $? -eq 0 ]; then
+                    run "service reload nginx"
+                    [ $? -ne 0 ] && error "Restart nginx by 'service reload nginx' in $server failed"
+                else
+                    run "nginx -s reload"
+                    [ $? -ne 0 ] && error "nginx -s reload in $server failed"
+                fi
+            success "Restarted nginx in $server"
+        ''')
+
+if __name__ == '__main__':
+    print(deploy_script({
+        'host': 'localhost',
+        'cert_path': '/etc/letsencrpyt/live/your.domain.com',
+        'deploy_to': '/root/letsencrpyt/live',
+        'restart_nginx': True,
+    }))
+
+    print(deploy_script({
+        'host': '192.168.1.1',
+        'port': 22,
+        'user': 'root',
+        'password': 'root',
+        'cert_path': '/etc/letsencrpyt/live/your.domain.com',
+        'deploy_to': '/root/letsencrpyt/live',
+        'restart_nginx': True,
+    }))

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -4,10 +4,11 @@
 import os
 import sys
 
-from .config import Config
-
 root_path = os.path.sep.join([os.path.split(os.path.realpath(__file__))[0], '..'])
 tlds_path = os.path.sep.join([root_path, 'tlds.txt'])
+
+sys.path.append(root_path)
+from lib import Config
 
 # @example extract_domain('m.domain.com') #=> ('m', 'domain.com')
 def extract_domain(domain):
@@ -27,9 +28,9 @@ def extract_domain(domain):
 def is_enable_deployment():
     try:
         deploy = Config.get('deploy', {})
-        remotes = deploy.get('remotes', [])
+        servers = deploy.get('servers', [])
 
-        for server in remotes:
+        for server in servers:
             if server and server.get('enable', False):
                 return True
         return False
@@ -37,10 +38,20 @@ def is_enable_deployment():
         print("utils#is_enable_deployment raise Exception: " + str(e))
         return False
 
-# if __name__ == '__main__':
-#     domains = sys.argv[1:]
+def is_localhost(host):
+    return host in ['127.0.0.1', '0.0.0.0', '::1', 'localhost']
 
-#     print('(sudomain, maindomain)')
+if __name__ == '__main__':
+    domains = sys.argv[1:]
 
-#     for domain in domains:
-#         print(extract_domain(domain))
+    print('Testing extract_domain...')
+    print('(sudomain, maindomain)')
+    for domain in domains:
+        print(extract_domain(domain))
+
+    print('Testing is_enable_deployment...')
+    print(is_enable_deployment())
+
+    print('Testing is_localhost...')
+    print(is_localhost('127.0.0.1'))
+    print(is_localhost('127.0.0.2'))

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -4,6 +4,8 @@
 import os
 import sys
 
+from .config import Config
+
 root_path = os.path.sep.join([os.path.split(os.path.realpath(__file__))[0], '..'])
 tlds_path = os.path.sep.join([root_path, 'tlds.txt'])
 
@@ -22,11 +24,23 @@ def extract_domain(domain):
 
     return ('', domain)
 
+def is_enable_deployment():
+    try:
+        deploy = Config.get('deploy', {})
+        remotes = deploy.get('remotes', [])
 
-if __name__ == '__main__':
-    domains = sys.argv[1:]
+        for server in remotes:
+            if server and server.get('enable', False):
+                return True
+        return False
+    except Exception as e:
+        print("utils#is_enable_deployment raise Exception: " + str(e))
+        return False
 
-    print('(sudomain, maindomain)')
+# if __name__ == '__main__':
+#     domains = sys.argv[1:]
 
-    for domain in domains:
-        print(extract_domain(domain))
+#     print('(sudomain, maindomain)')
+
+#     for domain in domains:
+#         print(extract_domain(domain))


### PR DESCRIPTION
### 关联 Issue

#1 

### 修改描述

1. 优化部署配置: 移除备份数设置，默认备份一份。移除全局部署启用设置，增加服务器级别的启用设置。调整 nginx 重启配置名

2. 优化本地部署过程，本地部署不使用 ssh 进行操作

3. 修复部署目标文件为软连接问题，若为软连接，直接覆盖其实际文件

### 测试

本地及远端情况已测试