### PR TITLE
修复部署文件为软链接问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@
 
 **Fixed bugs:**
 
-- Can't renew certificate if `deploy.server.deploy_to` set `/etc/letsencrypt/live` on local deployment [\#3](https://github.com/jinhucheung/letscertbot/pull/3)
+- Can't renew certificate if `deploy.server.deploy_to` set `/etc/letsencrypt/live` on local deployment [\#4](https://github.com/jinhucheung/letscertbot/pull/4)

--- a/bin/manual.py
+++ b/bin/manual.py
@@ -125,7 +125,7 @@ def main():
     parser.add_argument('-c', '--cleanup', help='cleanup hook', action='store_true')
     parser.add_argument('-t', '--test', help='test DNS API', action='store_true')
     parser.add_argument('--api', help='api type, default: aliyun', default='aliyun')
-    parser.add_argument('--domain', help='a domain for test DNS API')
+    parser.add_argument('-d', '--domain', help='a domain for test DNS API')
 
     args = parser.parse_args()
 

--- a/lib/script_templates.py
+++ b/lib/script_templates.py
@@ -96,8 +96,8 @@ class DeployScriptTemplate(BaseScriptTemplate):
                 use_ssh=${2:-1}
 
                 if [ $use_ssh -eq 1 ]; then
-                    [ "$password" ] || ssh_options="$ssh_options -o BatchMode=yes"
-                    cmd="ssh $ssh_options -p $port $server '$cmd'"
+                    [ "$password" ] || ssh_opts="$ssh_options -o BatchMode=yes"
+                    cmd="ssh $ssh_opts -p $port $server '$cmd'"
                 fi
                 [ "$password" ] && cmd="sshpass -p $password $cmd"
 


### PR DESCRIPTION
### 问题描述

当部署文件为软链接，若直接覆盖部署文件，本地环境将在续期发送错误，Certbot 会检查证书文件是否为软链接

### 修改描述

1. 调整 DNS API 脚本 domain 参数
2. 修复部署脚本 ssh BatchMode 重复
3. 修复部署脚本软链接命令，确保命令参数在远端执行